### PR TITLE
Fix "gitter join chat" url so that icon appears on README 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Gitter](https://badges.gitter.im/Join Chat.svg)](https://gitter.im/airbnb/javascript?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
+[![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/airbnb/javascript?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 
 # Airbnb JavaScript Guida allo Stile() {
 


### PR DESCRIPTION
(add `%20` for space between Join and Chat)